### PR TITLE
Fixed Path of output Presentation

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -10,7 +10,7 @@ Convert the AsciiDoc to HTML slides by invoking the `process-resources` goal (co
 
  $ mvn
 
-Open the file _target/generated-slides/slides.html_ in your browser to see the generated HTML file containing the reveal.js presentation deck.
+Open the file _target/generated-slides/slide.html_ in your browser to see the generated HTML file containing the reveal.js presentation deck.
 
 see also
 https://bcouetil.gitlab.io/academy/BP-asciidoc.html


### PR DESCRIPTION
After trying it out, I figured, that the generated html file is called `slide.html` and not `slides.html`